### PR TITLE
Stop using ChildNode.remove() because it’s not supported in IE and possibly PhantomJS

### DIFF
--- a/build/kalendae.js
+++ b/build/kalendae.js
@@ -1001,7 +1001,7 @@ Kalendae.Input.prototype = util.merge(Kalendae.prototype, {
 
 		util.removeEvent($input, 'keyup', this._events.inputKeyup);
 
-		$container.remove();
+		$container.parentElement.removeChild($container);
 	}
 });
 

--- a/build/kalendae.standalone.js
+++ b/build/kalendae.standalone.js
@@ -1001,7 +1001,7 @@ Kalendae.Input.prototype = util.merge(Kalendae.prototype, {
 
 		util.removeEvent($input, 'keyup', this._events.inputKeyup);
 
-		$container.remove();
+		$container.parentElement.removeChild($container);
 	}
 });
 

--- a/src/input.js
+++ b/src/input.js
@@ -172,7 +172,7 @@ Kalendae.Input.prototype = util.merge(Kalendae.prototype, {
 
 		util.removeEvent($input, 'keyup', this._events.inputKeyup);
 
-		$container.remove();
+		$container.parentElement.removeChild($container);
 	}
 });
 


### PR DESCRIPTION
Yep.
