### PR TITLE
Add touchstart event for container click on mobile

### DIFF
--- a/build/kalendae.js
+++ b/build/kalendae.js
@@ -163,7 +163,7 @@ var Kalendae = function (targetElement, options) {
 
 	self.draw();
 
-	util.addEvent($container, 'mousedown', function (event, target) {
+	var handleClickedContainer = function(event, target) {
 		var clickedDate;
 		if (util.hasClassName(target, classes.nextMonth)) {
 		//NEXT MONTH BUTTON
@@ -176,13 +176,13 @@ var Kalendae = function (targetElement, options) {
 		} else if (util.hasClassName(target, classes.previousMonth)) {
 		//PREVIOUS MONTH BUTTON
 			if (!self.disablePreviousMonth && self.publish('view-changed', self, ['previous-month']) !== false) {
-				self.viewStartDate.subtract('months',1);
+				self.viewStartDate.subtract(1, 'months');
 				self.draw();
 			}
 			return false;
 
 		} else if (util.hasClassName(target, classes.nextYear)) {
-		//NEXT MONTH BUTTON
+		//NEXT YEAR BUTTON
 			if (!self.disableNext && self.publish('view-changed', self, ['next-year']) !== false) {
 				self.viewStartDate.add(1, 'years');
 				self.draw();
@@ -190,7 +190,7 @@ var Kalendae = function (targetElement, options) {
 			return false;
 
 		} else if (util.hasClassName(target, classes.previousYear)) {
-		//PREVIOUS MONTH BUTTON
+		//PREVIOUS YEAR BUTTON
 			if (!self.disablePreviousMonth && self.publish('view-changed', self, ['previous-year']) !== false) {
 				self.viewStartDate.subtract('years',1);
 				self.draw();
@@ -234,8 +234,10 @@ var Kalendae = function (targetElement, options) {
 		}
 
 		return false;
-	});
+	};
 
+	util.addEvent($container, 'mousedown', handleClickedContainer);
+	util.addEvent($container, 'touchstart', handleClickedContainer);
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);

--- a/build/kalendae.js
+++ b/build/kalendae.js
@@ -236,8 +236,11 @@ var Kalendae = function (targetElement, options) {
 		return false;
 	};
 
-	util.addEvent($container, 'mousedown', handleClickedContainer);
-	util.addEvent($container, 'touchstart', handleClickedContainer);
+	if ('ontouchstart' in document.documentElement) {
+		util.addEvent($container, 'touchstart', handleClickedContainer);
+	} else {
+		util.addEvent($container, 'mousedown', handleClickedContainer);
+	}
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);
@@ -871,7 +874,11 @@ Kalendae.Input = function (targetElement, options) {
 	$container.style.display = 'none';
 	util.addClassName($container, classes.positioned);
 
-	this._events.containerMouseDown = util.addEvent($container, 'mousedown', function (event, target) {
+	this._events.containerMousedown = util.addEvent($container, 'mousedown', function (event, target) {
+		noclose = true; //IE8 doesn't obey event blocking when it comes to focusing, so we have to do this shit.
+	});
+
+	this._events.containerTouchstart = util.addEvent($container, 'touchstart', function (event, target) {
 		noclose = true; //IE8 doesn't obey event blocking when it comes to focusing, so we have to do this shit.
 	});
 
@@ -994,6 +1001,8 @@ Kalendae.Input.prototype = util.merge(Kalendae.prototype, {
 		var $input = this.input;
 
 		util.removeEvent($container, 'mousedown', this._events.containerMousedown);
+
+		util.removeEvent($container, 'touchstart', this._events.containerTouchstart);
 
 		util.removeEvent(window.document, 'mousedown', this._events.documentMousedown);
 

--- a/build/kalendae.standalone.js
+++ b/build/kalendae.standalone.js
@@ -163,7 +163,7 @@ var Kalendae = function (targetElement, options) {
 
 	self.draw();
 
-	util.addEvent($container, 'mousedown', function (event, target) {
+	var handleClickedContainer = function(event, target) {
 		var clickedDate;
 		if (util.hasClassName(target, classes.nextMonth)) {
 		//NEXT MONTH BUTTON
@@ -176,13 +176,13 @@ var Kalendae = function (targetElement, options) {
 		} else if (util.hasClassName(target, classes.previousMonth)) {
 		//PREVIOUS MONTH BUTTON
 			if (!self.disablePreviousMonth && self.publish('view-changed', self, ['previous-month']) !== false) {
-				self.viewStartDate.subtract('months',1);
+				self.viewStartDate.subtract(1, 'months');
 				self.draw();
 			}
 			return false;
 
 		} else if (util.hasClassName(target, classes.nextYear)) {
-		//NEXT MONTH BUTTON
+		//NEXT YEAR BUTTON
 			if (!self.disableNext && self.publish('view-changed', self, ['next-year']) !== false) {
 				self.viewStartDate.add(1, 'years');
 				self.draw();
@@ -190,7 +190,7 @@ var Kalendae = function (targetElement, options) {
 			return false;
 
 		} else if (util.hasClassName(target, classes.previousYear)) {
-		//PREVIOUS MONTH BUTTON
+		//PREVIOUS YEAR BUTTON
 			if (!self.disablePreviousMonth && self.publish('view-changed', self, ['previous-year']) !== false) {
 				self.viewStartDate.subtract('years',1);
 				self.draw();
@@ -234,8 +234,10 @@ var Kalendae = function (targetElement, options) {
 		}
 
 		return false;
-	});
+	};
 
+	util.addEvent($container, 'mousedown', handleClickedContainer);
+	util.addEvent($container, 'touchstart', handleClickedContainer);
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);

--- a/build/kalendae.standalone.js
+++ b/build/kalendae.standalone.js
@@ -236,8 +236,11 @@ var Kalendae = function (targetElement, options) {
 		return false;
 	};
 
-	util.addEvent($container, 'mousedown', handleClickedContainer);
-	util.addEvent($container, 'touchstart', handleClickedContainer);
+	if ('ontouchstart' in document.documentElement) {
+		util.addEvent($container, 'touchstart', handleClickedContainer);
+	} else {
+		util.addEvent($container, 'mousedown', handleClickedContainer);
+	}
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);
@@ -871,7 +874,11 @@ Kalendae.Input = function (targetElement, options) {
 	$container.style.display = 'none';
 	util.addClassName($container, classes.positioned);
 
-	this._events.containerMouseDown = util.addEvent($container, 'mousedown', function (event, target) {
+	this._events.containerMousedown = util.addEvent($container, 'mousedown', function (event, target) {
+		noclose = true; //IE8 doesn't obey event blocking when it comes to focusing, so we have to do this shit.
+	});
+
+	this._events.containerTouchstart = util.addEvent($container, 'touchstart', function (event, target) {
 		noclose = true; //IE8 doesn't obey event blocking when it comes to focusing, so we have to do this shit.
 	});
 
@@ -994,6 +1001,8 @@ Kalendae.Input.prototype = util.merge(Kalendae.prototype, {
 		var $input = this.input;
 
 		util.removeEvent($container, 'mousedown', this._events.containerMousedown);
+
+		util.removeEvent($container, 'touchstart', this._events.containerTouchstart);
 
 		util.removeEvent(window.document, 'mousedown', this._events.documentMousedown);
 

--- a/src/input.js
+++ b/src/input.js
@@ -40,7 +40,11 @@ Kalendae.Input = function (targetElement, options) {
 	$container.style.display = 'none';
 	util.addClassName($container, classes.positioned);
 
-	this._events.containerMouseDown = util.addEvent($container, 'mousedown', function (event, target) {
+	this._events.containerMousedown = util.addEvent($container, 'mousedown', function (event, target) {
+		noclose = true; //IE8 doesn't obey event blocking when it comes to focusing, so we have to do this shit.
+	});
+
+	this._events.containerTouchstart = util.addEvent($container, 'touchstart', function (event, target) {
 		noclose = true; //IE8 doesn't obey event blocking when it comes to focusing, so we have to do this shit.
 	});
 
@@ -163,6 +167,8 @@ Kalendae.Input.prototype = util.merge(Kalendae.prototype, {
 		var $input = this.input;
 
 		util.removeEvent($container, 'mousedown', this._events.containerMousedown);
+
+		util.removeEvent($container, 'touchstart', this._events.containerTouchstart);
 
 		util.removeEvent(window.document, 'mousedown', this._events.documentMousedown);
 

--- a/src/main.js
+++ b/src/main.js
@@ -154,7 +154,7 @@ var Kalendae = function (targetElement, options) {
 
 	self.draw();
 
-	util.addEvent($container, 'mousedown', function (event, target) {
+	var handleClickedContainer = function(event, target) {
 		var clickedDate;
 		if (util.hasClassName(target, classes.nextMonth)) {
 		//NEXT MONTH BUTTON
@@ -167,13 +167,13 @@ var Kalendae = function (targetElement, options) {
 		} else if (util.hasClassName(target, classes.previousMonth)) {
 		//PREVIOUS MONTH BUTTON
 			if (!self.disablePreviousMonth && self.publish('view-changed', self, ['previous-month']) !== false) {
-				self.viewStartDate.subtract('months',1);
+				self.viewStartDate.subtract(1, 'months');
 				self.draw();
 			}
 			return false;
 
 		} else if (util.hasClassName(target, classes.nextYear)) {
-		//NEXT MONTH BUTTON
+		//NEXT YEAR BUTTON
 			if (!self.disableNext && self.publish('view-changed', self, ['next-year']) !== false) {
 				self.viewStartDate.add(1, 'years');
 				self.draw();
@@ -181,7 +181,7 @@ var Kalendae = function (targetElement, options) {
 			return false;
 
 		} else if (util.hasClassName(target, classes.previousYear)) {
-		//PREVIOUS MONTH BUTTON
+		//PREVIOUS YEAR BUTTON
 			if (!self.disablePreviousMonth && self.publish('view-changed', self, ['previous-year']) !== false) {
 				self.viewStartDate.subtract('years',1);
 				self.draw();
@@ -225,8 +225,10 @@ var Kalendae = function (targetElement, options) {
 		}
 
 		return false;
-	});
+	};
 
+	util.addEvent($container, 'mousedown', handleClickedContainer);
+	util.addEvent($container, 'touchstart', handleClickedContainer);
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);

--- a/src/main.js
+++ b/src/main.js
@@ -227,8 +227,11 @@ var Kalendae = function (targetElement, options) {
 		return false;
 	};
 
-	util.addEvent($container, 'mousedown', handleClickedContainer);
-	util.addEvent($container, 'touchstart', handleClickedContainer);
+	if ('ontouchstart' in document.documentElement) {
+		util.addEvent($container, 'touchstart', handleClickedContainer);
+	} else {
+		util.addEvent($container, 'mousedown', handleClickedContainer);
+	}
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);


### PR DESCRIPTION
- Add `touchstart` alongside `mousedown` event to support mobile.
- Fix MONTH -> YEAR typo in comments.
- Fix `momentjs` warning on `subtract(timeSpan, number)` to `subtract(number, timeSpan)`.
