### PR TITLE
Support *both* touch and click events

### DIFF
--- a/build/kalendae.js
+++ b/build/kalendae.js
@@ -164,6 +164,7 @@ var Kalendae = function (targetElement, options) {
 	self.draw();
 
 	var handleClickedContainer = function(event, target) {
+		event.preventDefault();
 		var clickedDate;
 		if (util.hasClassName(target, classes.nextMonth)) {
 		//NEXT MONTH BUTTON
@@ -238,9 +239,9 @@ var Kalendae = function (targetElement, options) {
 
 	if ('ontouchstart' in document.documentElement) {
 		util.addEvent($container, 'touchstart', handleClickedContainer);
-	} else {
-		util.addEvent($container, 'mousedown', handleClickedContainer);
 	}
+
+	util.addEvent($container, 'mousedown', handleClickedContainer);
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);

--- a/build/kalendae.standalone.js
+++ b/build/kalendae.standalone.js
@@ -164,6 +164,7 @@ var Kalendae = function (targetElement, options) {
 	self.draw();
 
 	var handleClickedContainer = function(event, target) {
+		event.preventDefault();
 		var clickedDate;
 		if (util.hasClassName(target, classes.nextMonth)) {
 		//NEXT MONTH BUTTON
@@ -238,9 +239,9 @@ var Kalendae = function (targetElement, options) {
 
 	if ('ontouchstart' in document.documentElement) {
 		util.addEvent($container, 'touchstart', handleClickedContainer);
-	} else {
-		util.addEvent($container, 'mousedown', handleClickedContainer);
 	}
+
+	util.addEvent($container, 'mousedown', handleClickedContainer);
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);

--- a/src/main.js
+++ b/src/main.js
@@ -155,6 +155,7 @@ var Kalendae = function (targetElement, options) {
 	self.draw();
 
 	var handleClickedContainer = function(event, target) {
+		event.preventDefault();
 		var clickedDate;
 		if (util.hasClassName(target, classes.nextMonth)) {
 		//NEXT MONTH BUTTON
@@ -229,9 +230,9 @@ var Kalendae = function (targetElement, options) {
 
 	if ('ontouchstart' in document.documentElement) {
 		util.addEvent($container, 'touchstart', handleClickedContainer);
-	} else {
-		util.addEvent($container, 'mousedown', handleClickedContainer);
 	}
+
+	util.addEvent($container, 'mousedown', handleClickedContainer);
 
 	if (!!(opts.attachTo = util.$(opts.attachTo))) {
 		opts.attachTo.appendChild($container);


### PR DESCRIPTION
Instead of binding the `handleClickedContainer` to _either_ the `touchstart` or `mousedown` event, we now always bind if to `mousedown` _and_ only to `touchstart` if touch events are supported.

This is to accommodate devices that support _both_ events, like MS Surface or touchscreen-enabled Chromebook.

![](https://cloud.githubusercontent.com/assets/11348/12686583/78442280-c698-11e5-96a7-c5bcdacbd3ad.gif)
